### PR TITLE
Download specific tab from Google Sheet

### DIFF
--- a/.github/workflows/sheet2rdf.yml
+++ b/.github/workflows/sheet2rdf.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           FILE_NAME: ${{secrets.FILE_NAME}}
           SHEET_ID: ${{secrets.SHEET_ID}}
-          GID: ${{secrets.GID}}
+          SHEET_GID: ${{secrets.SHEET_GID}}
         run: |
           conda activate sheet2rdf          
           python ./src/sheet2xls.py

--- a/.github/workflows/sheet2rdf.yml
+++ b/.github/workflows/sheet2rdf.yml
@@ -21,12 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: "3.8"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Prepare
         shell: bash -l {0}
         run: |
@@ -36,6 +41,7 @@ jobs:
           conda create -n sheet2rdf python=3.8 pandas openpyxl requests
           conda activate sheet2rdf
           curl -L https://github.com/sparna-git/xls2rdf/releases/download/2.1.1/xls2rdf-app-2.1.1-onejar.jar -o xls2rdf.jar
+          mkdir -p logs
 
       - name: Fetch
         shell: bash -l {0}

--- a/.github/workflows/sheet2rdf.yml
+++ b/.github/workflows/sheet2rdf.yml
@@ -42,6 +42,7 @@ jobs:
         env:
           FILE_NAME: ${{secrets.FILE_NAME}}
           SHEET_ID: ${{secrets.SHEET_ID}}
+          GID: ${{secrets.GID}}
         run: |
           conda activate sheet2rdf          
           python ./src/sheet2xls.py

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 5. Go to **Settings -> Secrets and variables -> Actions -> New repository secret** and add the following secrets:
 - **`FILE_NAME`** — base name for output files (e.g., `vocabulary`)  
 - **`SHEET_ID`** — ID of your Google Sheet. You can find it from its URL.
+- **`GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet.
 - **`GRAPH`** — URI of the named graph to publish to  
 - **`DB_USER`** — Fuseki database username  
 - **`DB_PASS`** — Fuseki database password  
@@ -54,6 +55,7 @@ If you have updated the Google Sheet and want to preview the vocabulary in Skosm
 1. Go to **Settings -> Secrets and variables -> Codespaces -> New repository secret** and add the following secrets:
 - **`FILE_NAME`** — base name for output files (e.g., `vocabulary`)  
 - **`SHEET_ID`** — ID of your Google Sheet. You can find it from its URL.
+- **`GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet.
 
 2. In your GitHub repo, go to **Code -> Codespaces -> Create codespace on main**. This starts a VS Code environment and brings up Skosmos in Docker for preview.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 5. Go to **Settings -> Secrets and variables -> Actions -> New repository secret** and add the following secrets:
 - **`FILE_NAME`** — base name for output files (e.g., `vocabulary`)  
 - **`SHEET_ID`** — ID of your Google Sheet. You can find it from its URL.
-- **`GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet.
+- **`SHEET_GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet.
 - **`GRAPH`** — URI of the named graph to publish to  
 - **`DB_USER`** — Fuseki database username  
 - **`DB_PASS`** — Fuseki database password  
@@ -55,7 +55,7 @@ If you have updated the Google Sheet and want to preview the vocabulary in Skosm
 1. Go to **Settings -> Secrets and variables -> Codespaces -> New repository secret** and add the following secrets:
 - **`FILE_NAME`** — base name for output files (e.g., `vocabulary`)  
 - **`SHEET_ID`** — ID of your Google Sheet. You can find it from its URL.
-- **`GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet.
+- **`SHEET_GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet.
 
 2. In your GitHub repo, go to **Code -> Codespaces -> Create codespace on main**. This starts a VS Code environment and brings up Skosmos in Docker for preview.
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 4. Create your Github repository using this template.
 
 5. Go to **Settings -> Secrets and variables -> Actions -> New repository secret** and add the following secrets:
-- **`FILE_NAME`** — base name for output files (e.g., `vocabulary`)  
+- **`FILE_NAME`** — base name for output files (e.g., `my_vocabulary`)  
 - **`SHEET_ID`** — ID of your Google Sheet. You can find it from its URL.
 - **`SHEET_GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet. If you have only one tab, you do not need to set this variable.
-- **`GRAPH`** — URI of the named graph to publish to  
-- **`DB_USER`** — Fuseki database username  
-- **`DB_PASS`** — Fuseki database password  
-- **`SPARQL_ENDPOINT`** — URL of your Graph Store SPARQL endpoint  
+- **`GRAPH`** — URI of the named graph to publish to. For example: `http://example.org/graph/my_vocabulary`
+- **`DB_USER`** — Fuseki database username. You can find both username and password of database in the VM in `cat /etc/fuseki/shiro.ini` file.
+- **`DB_PASS`** — Fuseki database password.
+- **`SPARQL_ENDPOINT`** — URL of your Graph Store SPARQL endpoint, such as `http://YOUR_VM_IP:3030/DATABASE_NAME/data`.
 
 
 6. Preview your vocabulary before publishing. You can follow the steps in the section [Previewing Vocabulary in GitHub Codespaces](#previewing-vocabulary-in-github-codespaces).
@@ -25,7 +25,7 @@
 # Deploying Skosmos
 The official [tutorial](https://github.com/NatLibFi/Skosmos/wiki/InstallTutorial) assumes a local VM setup. When using a cloud VM, you need to:
 
-1. Replace `localhost` in tutorial instructions with your VM’s public IP.
+1. Replace `localhost` in tutorial instructions with your VM’s public IP when you are accessing it from outside of the VM.
 
 2. Open inbound TCP port **3030** in your VM’s network settings. You can find the tutorials for [Google Cloud](https://cloud.google.com/firewall/docs/using-firewalls), [Amazon Web Services](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/changing-security-group.html#add-remove-security-group-rules), [Microsoft Azure](https://learn.microsoft.com/en-us/azure/virtual-network/manage-network-security-group?tabs=network-security-group-portal).
 
@@ -33,18 +33,8 @@ The official [tutorial](https://github.com/NatLibFi/Skosmos/wiki/InstallTutorial
 
    ```
    sudo apt update
-   sudo apt install apache2 libapache2-mod-php8.1 php8.1 php8.1-xml php8.1-intl php8.1-mbstring php8.1-curl
+   sudo apt install -y apache2 php libapache2-mod-php php-xml php-intl php-mbstring php-curl
    ```
-
-4. If the `php composer.phar install --no-dev` command fails in the section [Install Skosmos](https://github.com/NatLibFi/Skosmos/wiki/InstallTutorial#install-skosmos), try running the following commands instead:
-
-   ```
-   sudo apt update
-   sudo apt install -y php8.1-zip unzip composer
-   composer clear-cache
-   php composer.phar install --no-dev
-   ```
-
 
 # Previewing Vocabulary in Skosmos Using GitHub Codespaces
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 5. Go to **Settings -> Secrets and variables -> Actions -> New repository secret** and add the following secrets:
 - **`FILE_NAME`** — base name for output files (e.g., `vocabulary`)  
 - **`SHEET_ID`** — ID of your Google Sheet. You can find it from its URL.
-- **`SHEET_GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet.
+- **`SHEET_GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet. If you have only one tab, you do not need to set this variable.
 - **`GRAPH`** — URI of the named graph to publish to  
 - **`DB_USER`** — Fuseki database username  
 - **`DB_PASS`** — Fuseki database password  
@@ -55,7 +55,7 @@ If you have updated the Google Sheet and want to preview the vocabulary in Skosm
 1. Go to **Settings -> Secrets and variables -> Codespaces -> New repository secret** and add the following secrets:
 - **`FILE_NAME`** — base name for output files (e.g., `vocabulary`)  
 - **`SHEET_ID`** — ID of your Google Sheet. You can find it from its URL.
-- **`SHEET_GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet.
+- **`SHEET_GID`** — Sheet GID (tab identifier). You can find it from the URL when you are in the desired tab of your Google Sheet. If you have only one tab, you do not need to set this variable.
 
 2. In your GitHub repo, go to **Code -> Codespaces -> Create codespace on main**. This starts a VS Code environment and brings up Skosmos in Docker for preview.
 

--- a/src/sheet2xls.py
+++ b/src/sheet2xls.py
@@ -3,9 +3,9 @@ import requests
 import sys
 import pandas as pd
 
-def getGoogleSheet(spreadsheet_id, gid, outDir, outFile):
+def getGoogleSheet(spreadsheet_id, spreadsheet_gid, outDir, outFile):
   
-  url = f'https://docs.google.com/spreadsheets/d/{spreadsheet_id}/export?format=csv&gid={gid}'
+  url = f'https://docs.google.com/spreadsheets/d/{spreadsheet_id}/export?format=csv&gid={spreadsheet_gid}'
   response = requests.get(url)
   if response.status_code == 200:
     filepath = os.path.join(outDir, outFile)
@@ -21,12 +21,12 @@ def getGoogleSheet(spreadsheet_id, gid, outDir, outFile):
 
 file_name = os.environ['FILE_NAME']
 sheet_id = os.environ["SHEET_ID"]
-gid = os.environ["GID"]
+sheet_gid = os.environ["sheet_GID"]
 
 outDir = './'
 
 os.makedirs(outDir, exist_ok = True)
-filepath = getGoogleSheet(sheet_id, gid, outDir, file_name + ".csv")
+filepath = getGoogleSheet(sheet_id, sheet_gid, outDir, file_name + ".csv")
 
 txt_delimiter = ","
 

--- a/src/sheet2xls.py
+++ b/src/sheet2xls.py
@@ -3,9 +3,9 @@ import requests
 import sys
 import pandas as pd
 
-def getGoogleSeet(spreadsheet_id, outDir, outFile):
+def getGoogleSheet(spreadsheet_id, gid, outDir, outFile):
   
-  url = f'https://docs.google.com/spreadsheets/d/{spreadsheet_id}/export?format=csv'
+  url = f'https://docs.google.com/spreadsheets/d/{spreadsheet_id}/export?format=csv&gid={gid}'
   response = requests.get(url)
   if response.status_code == 200:
     filepath = os.path.join(outDir, outFile)
@@ -21,11 +21,12 @@ def getGoogleSeet(spreadsheet_id, outDir, outFile):
 
 file_name = os.environ['FILE_NAME']
 sheet_id = os.environ["SHEET_ID"]
+gid = os.environ["GID"]
 
 outDir = './'
 
 os.makedirs(outDir, exist_ok = True)
-filepath = getGoogleSeet(sheet_id, outDir, file_name + ".csv")
+filepath = getGoogleSheet(sheet_id, gid, outDir, file_name + ".csv")
 
 txt_delimiter = ","
 

--- a/src/sheet2xls.py
+++ b/src/sheet2xls.py
@@ -21,7 +21,7 @@ def getGoogleSheet(spreadsheet_id, spreadsheet_gid, outDir, outFile):
 
 file_name = os.environ['FILE_NAME']
 sheet_id = os.environ["SHEET_ID"]
-sheet_gid = os.environ["sheet_GID"]
+sheet_gid = os.environ["SHEET_GID"]
 
 outDir = './'
 

--- a/src/sheet2xls.py
+++ b/src/sheet2xls.py
@@ -24,7 +24,7 @@ def getGoogleSheet(spreadsheet_id, spreadsheet_gid, outDir, outFile):
 
 file_name = os.environ['FILE_NAME']
 sheet_id = os.environ["SHEET_ID"]
-sheet_gid = os.environ["SHEET_GID"] or None
+sheet_gid = os.getenv("SHEET_GID")
 
 outDir = './'
 

--- a/src/sheet2xls.py
+++ b/src/sheet2xls.py
@@ -5,7 +5,10 @@ import pandas as pd
 
 def getGoogleSheet(spreadsheet_id, spreadsheet_gid, outDir, outFile):
   
-  url = f'https://docs.google.com/spreadsheets/d/{spreadsheet_id}/export?format=csv&gid={spreadsheet_gid}'
+  if spreadsheet_gid is None:
+    url = f'https://docs.google.com/spreadsheets/d/{spreadsheet_id}/export?format=csv'
+  else:
+    url = f'https://docs.google.com/spreadsheets/d/{spreadsheet_id}/export?format=csv&gid={spreadsheet_gid}'
   response = requests.get(url)
   if response.status_code == 200:
     filepath = os.path.join(outDir, outFile)
@@ -21,7 +24,7 @@ def getGoogleSheet(spreadsheet_id, spreadsheet_gid, outDir, outFile):
 
 file_name = os.environ['FILE_NAME']
 sheet_id = os.environ["SHEET_ID"]
-sheet_gid = os.environ["SHEET_GID"]
+sheet_gid = os.environ["SHEET_GID"] or None
 
 outDir = './'
 


### PR DESCRIPTION
Users can specify which tab of Google Sheet to download by adding the GID to the Github secrets. If there is only one tab, they do not need to set it.